### PR TITLE
Fix rule logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @azure-tools/rest-api-diff
 
+## 0.1.8 (TBD)
+
+- Rule application logic changed such that a flagged rule continues to run rules in case
+  there is a rule that markes it as NoViolation. If I diff is determined to be NoViolation,
+  no further rules are run.
+
 ## 0.1.7 (2024-11-25)
 
 - Fixed issue where paths were being sorted correctly, leading to unreadable visual diffs.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,4 @@ rule can make one of three determinations:
   This will be reported by the tool and may include an amplifying message. It will appear in a visual diff.
 - `RuleResult.ContinueProcessing`: the logic of the rule doesn't apply to this diff and thus the tool should continue processing rules.
 
-When processing a diff item against the rules, if either `NoViolation` or `FlaggedViolation` are returned by a rule, it immediately
-suspends processing any additional rules. If all rules return `ContinueProcessing` then the diff is assumed to affect the API surface
-area and is marked as `RuleResult.AssumedViolation`. It will be reported by the tool and will appear in a visual diff.
+When processing a diff item against the rules, if `NoViolation` is returned by a rule, it immediately suspends processing additional rules. If `FlaggedViolation` is returned, rules will continue to be processed in case another rule marks it as `NoViolation`. If all rules are run and no determination is made, then the diff is assumed to affect the API surface area and is tracked as an assumed violation. It will be reported by the tool and will appear in a visual diff. When violations are grouped, these violations will appear in the `UNGROUPED` group.

--- a/test/rest-api-diff.test.ts
+++ b/test/rest-api-diff.test.ts
@@ -6,6 +6,7 @@ import { loadPaths, toSorted } from "../src/util.js";
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { fail } from "assert";
 
 it("config should group violations when --group-violations is set", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "test-output-"));
@@ -158,4 +159,12 @@ it("should compare folders with external references", async () => {
   client.buildOutput();
   const [lhs, rhs] = client.resultFiles!.normal;
   expect(rhs).toStrictEqual(lhs);
+});
+
+it("a rule that declares noViolation should override a rule that flags a violation", async () => {
+  fail("Not implemented");
+});
+
+it("matching no rule should results in an UNGROUPED violation", async () => {
+  fail("Not implemented");
 });


### PR DESCRIPTION
Allows `FlaggedViolations` to be overriden by other rules that would render something `NoViolation`.