### PR TITLE
Case-insensitive path parsing for management plane

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -415,6 +415,6 @@ export class SwaggerParser {
       }
     }
     normalizedPath = pathComponents.join("");
-    return normalizedPath;
+    return normalizedPath.toLowerCase();
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -415,6 +415,10 @@ export class SwaggerParser {
       }
     }
     normalizedPath = pathComponents.join("");
-    return normalizedPath.toLowerCase();
+    // for management plane, path is case-insensitive
+    if (normalizedPath.startsWith("management.azure.com")) {
+      normalizedPath = normalizedPath.toLowerCase();
+    }
+    return normalizedPath;
   }
 }

--- a/test/files/test3a.json
+++ b/test/files/test3a.json
@@ -1,0 +1,34 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "(title)",
+    "version": "0000-00-00",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": ["https"],
+  "produces": ["application/json"],
+  "consumes": ["application/json"],
+  "tags": [],
+  "paths": {
+    "/getSomeFooThing": {
+      "get": {
+        "operationId": "GetFoo",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/test/files/test3a.json
+++ b/test/files/test3a.json
@@ -14,7 +14,21 @@
   "consumes": ["application/json"],
   "tags": [],
   "paths": {
-    "/getSomeFooThing": {
+    "blah.blah.com/getSomeFooThing": {
+      "get": {
+        "operationId": "GetFoo",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "management.azure.com/getSomeFooThing": {
       "get": {
         "operationId": "GetFoo",
         "parameters": [],

--- a/test/files/test3b.json
+++ b/test/files/test3b.json
@@ -1,0 +1,34 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "(title)",
+    "version": "0000-00-00",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": ["https"],
+  "produces": ["application/json"],
+  "consumes": ["application/json"],
+  "tags": [],
+  "paths": {
+    "/getsomefoothing": {
+      "get": {
+        "operationId": "GetFoo",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {},
+  "parameters": {}
+}

--- a/test/files/test3b.json
+++ b/test/files/test3b.json
@@ -14,7 +14,21 @@
   "consumes": ["application/json"],
   "tags": [],
   "paths": {
-    "/getsomefoothing": {
+    "blah.blah.com/getsomefoothing": {
+      "get": {
+        "operationId": "GetFoo",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "management.azure.com/getsomefoothing": {
       "get": {
         "operationId": "GetFoo",
         "parameters": [],

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -88,5 +88,8 @@ it("should match path in a case-insensitive way", async () => {
   client.processDiff();
   expect(client.diffResults?.flaggedViolations.length).toBe(0);
   expect(client.diffResults?.noViolations.length).toBe(0);
-  expect(client.diffResults?.assumedViolations.length).toBe(0);
+  expect(client.diffResults?.assumedViolations.length).toBe(2);
+  for (const diff of client.diffResults?.assumedViolations || []) {
+    expect(diff.diff.path![1].startsWith("blah.blah.com")).toBe(true);
+  }
 });

--- a/test/path.test.ts
+++ b/test/path.test.ts
@@ -75,3 +75,18 @@ it("expands x-ms-paths", async () => {
   expect(lhsPaths.length).toBe(2);
   assertSorted(lhsPaths);
 });
+
+it("should match path in a case-insensitive way", async () => {
+  const config: DiffClientConfig = {
+    lhs: ["test/files/test3a.json"],
+    rhs: ["test/files/test3b.json"],
+    args: {},
+    rules: [],
+  };
+  const client = await TestableDiffClient.create(config);
+  client.parse();
+  client.processDiff();
+  expect(client.diffResults?.flaggedViolations.length).toBe(0);
+  expect(client.diffResults?.noViolations.length).toBe(0);
+  expect(client.diffResults?.assumedViolations.length).toBe(0);
+});


### PR DESCRIPTION
Compares paths in a case insensitive way when the path starts with `management.azure.com`. 