### PR TITLE
Squished paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ but will not search subfolders.
   which exist solely for code re-use, aren't relevant to that question unless those definitions are used
   with a request or response. Hence, they are, by defult, pruned from the output. If you want to preserve
   these, for example to compare the definitions themselves between two Swaggers, provide this flag.
+- `--flatten-paths`: The default format of paths in the output is an array of path segments. If you prefer
+  to flatten these into a forward-slash delimited string, provide this flag.
 
 ### .env File
 

--- a/src/diff-client.ts
+++ b/src/diff-client.ts
@@ -203,10 +203,8 @@ export class DiffClient {
     const assumedViolations = this.diffResults.assumedViolations ?? [];
     const allViolations = [...flaggedViolations, ...assumedViolations];
 
-    const diffResult = this.#buildDiffFile(convertDiffItems(allViolations));
-    const invDiffResult = this.#buildDiffFile(
-      convertDiffItems(this.diffResults.noViolations)
-    );
+    const diffResult = this.#buildDiffFile(allViolations);
+    const invDiffResult = this.#buildDiffFile(this.diffResults.noViolations);
 
     this.resultFiles = {
       raw: [this.lhs, this.rhs],

--- a/src/diff-client.ts
+++ b/src/diff-client.ts
@@ -203,6 +203,11 @@ export class DiffClient {
     const assumedViolations = this.diffResults.assumedViolations ?? [];
     const allViolations = [...flaggedViolations, ...assumedViolations];
 
+    const diffResult = this.#buildDiffFile(convertDiffItems(allViolations));
+    const invDiffResult = this.#buildDiffFile(
+      convertDiffItems(this.diffResults.noViolations)
+    );
+
     this.resultFiles = {
       raw: [this.lhs, this.rhs],
       normal: this.#pruneDocuments(
@@ -211,8 +216,8 @@ export class DiffClient {
         this.diffResults.noViolations
       ),
       inverse: this.#pruneDocuments(this.lhs, this.rhs, allViolations),
-      diff: this.#buildDiffFile(allViolations),
-      diffInverse: this.#buildDiffFile(this.diffResults.noViolations),
+      diff: diffResult,
+      diffInverse: invDiffResult,
     };
   }
 
@@ -663,4 +668,19 @@ interface ResultSummary {
   assumedRules: number | undefined;
   unresolvedReferences: number;
   unreferencedObjects: number;
+}
+
+function convertDiffItems(items: DiffItem[]): any[] {
+  const results: any[] = [];
+  for (const item of items) {
+    const allItem = { ...item };
+    const diff = { ...allItem.diff };
+    const path = diff.path;
+    // join and url-encode the path segments
+    const fullPath = path!.map((x: string) => encodeURIComponent(x)).join("/");
+    (diff as any).path = fullPath;
+    allItem.diff = diff;
+    results.push(allItem);
+  }
+  return results;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,12 @@ const args = await yargs(hideBin(process.argv))
     describe: "The folder to output artifacts to.",
     default: process.env.OUTPUT_FOLDER ?? "./output",
   })
+  .options("flatten-paths", {
+    type: "boolean",
+    describe:
+      "Flatten paths in the output from an array of segments to a single line.",
+    default: process.env.FLATTEN_PATHS,
+  })
   .options("typespec-compiler-path", {
     type: "string",
     describe:

--- a/test/rest-api-diff.test.ts
+++ b/test/rest-api-diff.test.ts
@@ -53,6 +53,55 @@ it("config should group violations when --group-violations is set", async () => 
   }
 });
 
+it("config should flatten paths when --flatten-paths is set", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "test-output-"));
+  const args = { "flatten-paths": true, "output-folder": tempDir };
+  const config: DiffClientConfig = {
+    lhs: ["test/files/test2a.json"],
+    rhs: ["test/files/test2b.json"],
+    args: args,
+    rules: getApplicableRules(args),
+  };
+  const client = await TestableDiffClient.create(config);
+  client.parse();
+  client.processDiff();
+  client.buildOutput();
+  client.writeOutput();
+
+  const diffPath = path.join(tempDir, "diff.json");
+  const items = JSON.parse(fs.readFileSync(diffPath, "utf8"));
+  expect(items[0].diff.path).toEqual(
+    "paths/%20%/get/responses/200/schema/properties/age/format"
+  );
+});
+
+it("config should flatten paths when --flatten-paths and --group-violations is set", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "test-output-"));
+  const args = {
+    "flatten-paths": true,
+    "group-violations": true,
+    "output-folder": tempDir,
+  };
+  const config: DiffClientConfig = {
+    lhs: ["test/files/test2a.json"],
+    rhs: ["test/files/test2b.json"],
+    args: args,
+    rules: getApplicableRules(args),
+  };
+  const client = await TestableDiffClient.create(config);
+  client.parse();
+  client.processDiff();
+  client.buildOutput();
+  client.writeOutput();
+
+  const diffPath = path.join(tempDir, "diff.json");
+  const diffFile = JSON.parse(fs.readFileSync(diffPath, "utf8"));
+  const items = diffFile["Changed_format (AUTO)"];
+  expect(items[0].diff.path).toEqual(
+    "paths/%20%/get/responses/200/schema/properties/age/format"
+  );
+});
+
 it("config should not group violations when --group-violations is not set", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "test-output-"));
   const args = { "output-folder": tempDir };

--- a/test/rest-api-diff.test.ts
+++ b/test/rest-api-diff.test.ts
@@ -71,7 +71,7 @@ it("config should flatten paths when --flatten-paths is set", async () => {
   const diffPath = path.join(tempDir, "diff.json");
   const items = JSON.parse(fs.readFileSync(diffPath, "utf8"));
   expect(items[0].diff.path).toEqual(
-    "paths/%20%/get/responses/200/schema/properties/age/format"
+    "paths/%2F/get/responses/200/schema/properties/age/format"
   );
 });
 
@@ -96,9 +96,9 @@ it("config should flatten paths when --flatten-paths and --group-violations is s
 
   const diffPath = path.join(tempDir, "diff.json");
   const diffFile = JSON.parse(fs.readFileSync(diffPath, "utf8"));
-  const items = diffFile["Changed_format (AUTO)"];
+  const items = diffFile["Changed_format (AUTO)"].items;
   expect(items[0].diff.path).toEqual(
-    "paths/%20%/get/responses/200/schema/properties/age/format"
+    "paths/%2F/get/responses/200/schema/properties/age/format"
   );
 });
 


### PR DESCRIPTION
Changes the path from an array of segments to a single line to make it easier to read (arguably).